### PR TITLE
bunch of prefixing stuff needed to run in alpha hosted env

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,9 +13,9 @@
     "test": "yarn run jest --config=jest/jest.config.js",
     "start": "yarn pm2 start pm2.config.cjs --no-autorestart",
     "stop": "yarn pm2 stop all && yarn pm2 delete all",
-    "api-logs": "yarn pm2 logs daorectory-api",
-    "api-build-logs": "yarn pm2 logs daorectory-api-build",
-    "ui-logs": "yarn pm2 logs daorectory-ui",
+    "logs-api": "yarn pm2 logs daorectory-api",
+    "logs-api-build": "yarn pm2 logs daorectory-api-build",
+    "logs-ui": "yarn pm2 logs daorectory-ui",
     "connect": "aws ssm start-session --target i-0ebf6ea61528ad033"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,10 @@
     "get-secrets": "aws s3 cp s3://tmnt-secrets-development/ethonline2021/.env secrets && touch packages/daemon/.env && cat secrets >> packages/daemon/.env && rm secrets",
     "test": "yarn run jest --config=jest/jest.config.js",
     "start": "yarn pm2 start pm2.config.cjs --no-autorestart",
-    "stop": "pm2 stop all && pm2 delete all",
+    "stop": "yarn pm2 stop all && yarn pm2 delete all",
+    "api-logs": "yarn pm2 logs daorectory-api",
+    "api-build-logs": "yarn pm2 logs daorectory-api-build",
+    "ui-logs": "yarn pm2 logs daorectory-ui",
     "connect": "aws ssm start-session --target i-0ebf6ea61528ad033"
   },
   "devDependencies": {

--- a/packages/d-space/package.json
+++ b/packages/d-space/package.json
@@ -28,6 +28,7 @@
     "web-vitals": "^1.0.1"
   },
   "scripts": {
+    "d-space:start-hosted": "craco start",
     "d-space:start": "PUBLIC_URL=http://localhost:3000/ethonline2021 REACT_APP_ENV_PREFIX=/ethonline2021 REACT_APP_API_HOST=http://localhost:8081/ethonline2021 craco start",
     "d-space:build": "craco build",
     "d-space:test": "craco test"

--- a/packages/d-space/package.json
+++ b/packages/d-space/package.json
@@ -28,7 +28,7 @@
     "web-vitals": "^1.0.1"
   },
   "scripts": {
-    "d-space:start-hosted": "craco start",
+    "d-space:start-hosted": "PUBLIC_URL=https://alpha.sobol.io/ethonline2021 REACT_APP_ENV_PREFIX=/ethonline2021 REACT_APP_API_HOST=https://alpha.sobol.io/ethonline2021 craco start",
     "d-space:start": "PUBLIC_URL=http://localhost:3000/ethonline2021 REACT_APP_ENV_PREFIX=/ethonline2021 REACT_APP_API_HOST=http://localhost:8081/ethonline2021 craco start",
     "d-space:build": "craco build",
     "d-space:test": "craco test"

--- a/packages/d-space/package.json
+++ b/packages/d-space/package.json
@@ -28,7 +28,7 @@
     "web-vitals": "^1.0.1"
   },
   "scripts": {
-    "d-space:start": "craco start",
+    "d-space:start": "PUBLIC_URL=http://localhost:3000/ethonline2021 REACT_APP_ENV_PREFIX=/ethonline2021 REACT_APP_API_HOST=http://localhost:8081/ethonline2021 craco start",
     "d-space:build": "craco build",
     "d-space:test": "craco test"
   },

--- a/packages/d-space/src/ApiClient.ts
+++ b/packages/d-space/src/ApiClient.ts
@@ -1,35 +1,39 @@
 import type { DaoProfileVc, PunkProfileVc } from '@sobol/daemon-types/veramo-types';
 import { KudosVc, SecondedKudosVc } from '@sobol/daemon-types/veramo-types';
 
+const API_HOST = process.env.REACT_APP_API_HOST || 'http://localhost:8081';
+const API_URI = `${API_HOST}/api`;
+console.log(`ApiClient API_URI: ${API_URI}`);
+
 const ApiClient = {
   Vcs: {
     getDaos: async () => {
-      const response = await fetch('http://localhost:8081/vcs/daos');
+      const response = await fetch(`${API_URI}/vcs/daos`);
       const result = await response.json();
       return result as DaoProfileVc[];
     },
     getDao: async (daoId: string) => {
-      const response = await fetch(`http://localhost:8081/vcs/daos/${daoId}`);
+      const response = await fetch(`${API_URI}/vcs/daos/${daoId}`);
       const result = await response.json();
       return result as DaoProfileVc;
     },
     getPunks: async () => {
-      const response = await fetch('http://localhost:8081/vcs/punks');
+      const response = await fetch(`${API_URI}/vcs/punks`);
       const result = await response.json();
       return result as PunkProfileVc[];
     },
     getPunk: async (punkId: string) => {
-      const response = await fetch(`http://localhost:8081/vcs/punks/${punkId}`);
+      const response = await fetch(`${API_URI}/vcs/punks/${punkId}`);
       const result = await response.json();
       return result as PunkProfileVc;
     },
     getPunkKudos: async (punkId: string) => {
-      const response = await fetch(`http://localhost:8081/vcs/punks/${punkId}/kudos`);
+      const response = await fetch(`${API_URI}/vcs/punks/${punkId}/kudos`);
       const { kudos, secondedKudos } = await response.json();
       return { kudos, secondedKudos } as { kudos: KudosVc[], secondedKudos: SecondedKudosVc[] };
     },
     getAllKudos: async () => {
-      const response = await fetch(`http://localhost:8081/vcs/kudos`);
+      const response = await fetch(`${API_URI}/vcs/kudos`);
       const { kudos, secondedKudos } = await response.json();
       return { kudos, secondedKudos } as { kudos: KudosVc[], secondedKudos: SecondedKudosVc[] };
     },

--- a/packages/d-space/src/components/listing/ListingCard.tsx
+++ b/packages/d-space/src/components/listing/ListingCard.tsx
@@ -5,6 +5,8 @@ import { NavLink } from "react-router-dom";
 import {AppContext} from "../../App";
 import { isProfilePunk } from "../profile/ProfileContainer";
 
+const routePrefix = process.env.REACT_APP_ENV_PREFIX;
+
 type Props = {
   object: DaoProfileVc | PunkProfileVc,
   type: string,
@@ -16,7 +18,7 @@ const ListingCard: FC<Props> = ({
 }) => {
   const isPunk = isProfilePunk(object, type);
   const { credentialSubject: { avatarUrl, name, discordId } } = object;
-  const url = `/${type}/${discordId}`;
+  const url = `${routePrefix}/${type}/${discordId}`;
 
   const { kudosByPunkId } = useContext(AppContext);
   const punks = useMemo(() => Object.entries(kudosByPunkId)

--- a/packages/d-space/src/components/listing/ListingCard.tsx
+++ b/packages/d-space/src/components/listing/ListingCard.tsx
@@ -34,7 +34,7 @@ const ListingCard: FC<Props> = ({
       <Card
         className="ListingCard"
         hoverable
-        // cover={<img alt="example" src="/card-bg.png" />}
+        // cover={<img alt="example" src={`${routePrefix}/card-bg.png`} />}
       >
         <div className="ListingCard--body">
           <div className="ListingCard--avatar">

--- a/packages/d-space/src/components/profile/KudoCard.tsx
+++ b/packages/d-space/src/components/profile/KudoCard.tsx
@@ -15,6 +15,8 @@ type Props = {
   seconders: number,
 }
 
+const routePrefix = process.env.REACT_APP_ENV_PREFIX;
+
 const KudoCard: FC<Props> = ({
   kudos,
   issuerProfile,
@@ -49,7 +51,7 @@ const KudoCard: FC<Props> = ({
           <>
             <ProfileLink
               title={issuerProfile?.credentialSubject?.name || ''}
-              to={`/${Objects.Punk}/${issuerProfile?.credentialSubject?.discordId}`}
+              to={`${routePrefix}/${Objects.Punk}/${issuerProfile?.credentialSubject?.discordId}`}
               src={issuerProfile?.credentialSubject?.avatarUrl}
               size="large"
             /> {dot} DID
@@ -63,7 +65,7 @@ const KudoCard: FC<Props> = ({
           <ProfileLink
             title={dao?.credentialSubject?.name}
             src={dao?.credentialSubject?.avatarUrl}
-            to={`/${Objects.Dao}/${dao?.credentialSubject?.discordId}`}
+            to={`${routePrefix}/${Objects.Dao}/${dao?.credentialSubject?.discordId}`}
             size="small"
           /> {dot} {channel} {dot} DID {dot} Seconders ({seconders})
         </div>

--- a/packages/d-space/src/components/profile/KudoCard.tsx
+++ b/packages/d-space/src/components/profile/KudoCard.tsx
@@ -10,7 +10,8 @@ type Props = {
   kudos: KudosVc,
   issuerProfile?: PunkProfileVc,
   dao?: DaoProfileVc,
-  regarding: string,
+  message: string,
+  description: string,
   channel: string,
   seconders: number,
 }
@@ -21,7 +22,8 @@ const KudoCard: FC<Props> = ({
   kudos,
   issuerProfile,
   dao,
-  regarding,
+  message,
+  description,
   channel,
   seconders,
 }) => {
@@ -60,7 +62,7 @@ const KudoCard: FC<Props> = ({
         actions={[cardButtons]}
         className="ProfileCard"
       >
-        <p>{regarding}</p>
+        <p>{['.','!','?'].includes(message[message.length-1]) ? `${message} ` : `${message}. `} {description}</p>
         <div className="ProfileCard--info">
           <ProfileLink
             title={dao?.credentialSubject?.name}

--- a/packages/d-space/src/components/profile/KudoCard.tsx
+++ b/packages/d-space/src/components/profile/KudoCard.tsx
@@ -62,7 +62,8 @@ const KudoCard: FC<Props> = ({
         actions={[cardButtons]}
         className="ProfileCard"
       >
-        <p>{['.','!','?'].includes(message[message.length-1]) ? `${message} ` : `${message}. `} {description}</p>
+        <p>{['.','!','?'].includes(message[message.length-1]) ? `${message}` : `${message}.`}</p>
+        <p>Regarding: {description}</p>
         <div className="ProfileCard--info">
           <ProfileLink
             title={dao?.credentialSubject?.name}

--- a/packages/d-space/src/components/profile/ProfileContainer.tsx
+++ b/packages/d-space/src/components/profile/ProfileContainer.tsx
@@ -16,6 +16,8 @@ import ProfilePunks from './ProfilePunks';
 import {Prism as SyntaxHighlighter} from "react-syntax-highlighter";
 import {darcula} from "react-syntax-highlighter/dist/esm/styles/prism";
 
+const routePrefix = process.env.REACT_APP_ENV_PREFIX;
+
 type Props = {
   profile: PunkProfileVc | DaoProfileVc | null,
   type: string,
@@ -63,7 +65,7 @@ const ProfileContainer: FC<Props> = ({
                 <ProfileLink
                   title={profile?.credentialSubject.handle}
                   to="#"
-                  src="/discord.png"
+                  src={`${routePrefix}/discord.png`}
                   size="small"
                 />
               )}

--- a/packages/d-space/src/components/profile/ProfileDAOs.tsx
+++ b/packages/d-space/src/components/profile/ProfileDAOs.tsx
@@ -7,6 +7,8 @@ import _ from 'lodash';
 import { AppContext } from '../../App';
 import { Objects } from '../../config/constants';
 
+const routePrefix = process.env.REACT_APP_ENV_PREFIX;
+
 const ProfileDAOs: FC<{ kudos: KudosVc[] }> = ({ kudos }) => {
   const { daoProfilesById } = useContext(AppContext);
   const daoIds = useMemo(() => Object.entries(
@@ -21,7 +23,7 @@ const ProfileDAOs: FC<{ kudos: KudosVc[] }> = ({ kudos }) => {
         return (
           <ProfileLink
             title={dao?.credentialSubject?.name}
-            to={`/${Objects.Dao}/${daoId}`}
+            to={`${routePrefix}/${Objects.Dao}/${daoId}`}
             src={dao?.credentialSubject?.avatarUrl}
             isTile
             badgeCount={ks.length}

--- a/packages/d-space/src/components/profile/ProfilePunks.tsx
+++ b/packages/d-space/src/components/profile/ProfilePunks.tsx
@@ -5,6 +5,8 @@ import { FC } from 'react';
 import { AppContext } from '../../App';
 import { Objects } from '../../config/constants';
 
+const routePrefix = process.env.REACT_APP_ENV_PREFIX;
+
 const ProfilePunks: FC<{ daoId?: string }> = ({ daoId }) => {
   const { kudosByPunkId, punkProfilesById } = useContext(AppContext);
   const punks = useMemo(() => Object.entries(kudosByPunkId)
@@ -20,7 +22,7 @@ const ProfilePunks: FC<{ daoId?: string }> = ({ daoId }) => {
         return (
           <ProfileLink
             title={punk?.credentialSubject?.name}
-            to={`/${Objects.Punk}/${punkId}`}
+            to={`${routePrefix}/${Objects.Punk}/${punkId}`}
             src={punk?.credentialSubject?.avatarUrl}
             isTile
             badgeCount={kudos.length}

--- a/packages/d-space/src/components/profile/ProfileTimeline.tsx
+++ b/packages/d-space/src/components/profile/ProfileTimeline.tsx
@@ -30,7 +30,8 @@ const KudosTimelineItem: FC<{ kudos: KudosVc, secondedKudos: SecondedKudosVc[] }
         kudos={kudos}
         issuerProfile={issuerPunk}
         dao={dao}
-        regarding={kudos.credentialSubject.description}
+        message={kudos.credentialSubject.message}
+        description={kudos.credentialSubject.description}
         channel={kudos.credentialSubject.channel}
         seconders={seconders.length}
       />

--- a/packages/d-space/src/layouts/Background.tsx
+++ b/packages/d-space/src/layouts/Background.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 
-const background = "linear-gradient(180deg, rgba(0, 0, 0, 0) 0%, #181A25 100%), url('/bg.jpg')"
+const routePrefix = process.env.REACT_APP_ENV_PREFIX;
+
+const background = `linear-gradient(180deg, rgba(0, 0, 0, 0) 0%, #181A25 100%), url('${routePrefix}/bg.jpg')`
 
 const Background = () => (
   <div className="Background">

--- a/packages/d-space/src/layouts/Header.tsx
+++ b/packages/d-space/src/layouts/Header.tsx
@@ -6,13 +6,15 @@ import { Routes } from "../routes/Router";
 
 const { Header: AntdHeader } = Layout;
 
+const routePrefix = process.env.REACT_APP_ENV_PREFIX;
+
 const Header = () => {
   const { pathname } = useLocation();
 
   return (
     <AntdHeader className="Header">
       <a href="https://sobol.io/" target="_blank"  rel="noreferrer">
-        <img alt="Sobol" src="/logo-dark.png" className="Header--logo" />
+        <img alt="Sobol" src={`${routePrefix}/logo-dark.png`} className="Header--logo" />
       </a>
       <Menu theme="dark" mode="horizontal" selectedKeys={[pathname]} className="Header--menu">
         <Menu.Item key={Routes.Daos}>

--- a/packages/d-space/src/routes/Router.tsx
+++ b/packages/d-space/src/routes/Router.tsx
@@ -10,11 +10,13 @@ import Listing from "./Listing";
 import Profile from "./Profile";
 import { Objects, Pages } from "../config/constants";
 
+const routePrefix = process.env.REACT_APP_ENV_PREFIX;
+
 export const Routes = {
-  Daos: `/${Pages.Daos}`,
-  Punks: `/${Pages.Punks}`,
-  Dao: `/${Pages.Dao}/:id`,
-  Punk: `/${Pages.Punk}/:id`,
+  Daos: `${routePrefix}/${Pages.Daos}`,
+  Punks: `${routePrefix}/${Pages.Punks}`,
+  Dao: `${routePrefix}/${Pages.Dao}/:id`,
+  Punk: `${routePrefix}/${Pages.Punk}/:id`,
 };
 
 const Router = () => {

--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -6,9 +6,9 @@
   "private": true,
   "scripts": {
     "daemon:build-dev": "tsc --watch --project tsconfig.build.json",
-    "daemon:run": "yarn run nodemon ./dist/index.js --watch dist/",
-    "daemon:debug": "yarn run nodemon --inspect=9090 ./dist/index.js --watch dist/",
-    "daemon:debug-break": "yarn run nodemon --inspect-brk=localhost:9222 ./dist/index.js",
+    "daemon:run": "URI_PREFIX=/ethonline2021 yarn run nodemon ./dist/index.js --watch dist/",
+    "daemon:debug": "URI_PREFIX=/ethonline2021 yarn run nodemon --inspect=9090 ./dist/index.js --watch dist/",
+    "daemon:debug-break": "URI_PREFIX=/ethonline2021 yarn run nodemon --inspect-brk=localhost:9222 ./dist/index.js",
     "daemon:deploy-commands": "yarn node ./dist/scripts/deploy-commands.js",
     "daemon:generate-data": "yarn node ./dist/scripts/generate-data.js",
     "daemon:debug-generate-data": "yarn run nodemon ./dist/scripts/generate-data.js",

--- a/packages/daemon/src/api/index.ts
+++ b/packages/daemon/src/api/index.ts
@@ -4,16 +4,18 @@ import http from 'http';
 import didsRouter from './dids.router';
 import vcsRouter from './vcs.router';
 
+const URI_PREFIX = process.env.URI_PREFIX;
+
 const app = express();
 app.use(cors({
   origin: '*',
 }));
-app.use('/dids', didsRouter);
-app.use('/vcs', vcsRouter);
+app.use(`${URI_PREFIX}/api/dids`, didsRouter);
+app.use(`${URI_PREFIX}/api/vcs`, vcsRouter);
 
 const server = http.createServer(app);
 server.listen(8081);
 
-console.log('Server listening on port 8081');
+console.log(`Server listening on port 8081:${URI_PREFIX}/api`);
 
 export default server;

--- a/packages/daemon/src/discord/discord-setup.ts
+++ b/packages/daemon/src/discord/discord-setup.ts
@@ -14,122 +14,143 @@ console.log('Starting Daemon Discord bot...');
 discordClient.on('ready', async () => {
   console.log('Daemon Discord client is ready to receive commands');
 
-  await Promise.all(discordClient.guilds.cache.map(async (guild) => {
-    console.log(`Getting or creating DID for ${guild.name}/${guild.id}`);
-    const vc = await createDaoProfileVc(guild.id, {
-      name: guild.name,
-      discordId: guild.id,
-      avatarUrl: guild.iconURL({ size: 512 }),
-    });
-    console.log(vc);
-  }));
-  console.log('Finished creating DIDs/VCs for all guilds');
+  try {
+    await Promise.all(discordClient.guilds.cache.map(async (guild) => {
+      console.log(`Getting or creating DID for ${guild.name}/${guild.id}`);
+      const vc = await createDaoProfileVc(guild.id, {
+        name: guild.name,
+        discordId: guild.id,
+        avatarUrl: guild.iconURL({ size: 512 }),
+      });
+      console.log(vc);
+    }));
+    console.log('Finished creating DIDs/VCs for all guilds');
+  } catch(e) {
+    console.error('discordClient.ready', e);
+  }
 });
 
 discordClient.on('interactionCreate', async (interaction) => {
-  if (interaction.isCommand() && interaction.inGuild()) {
-    const subcommand = interaction.options.getSubcommand();
-    switch ([interaction.commandName, subcommand].join('.')) {
-      case 'daemon.kudos': {
-        const recipientOption = interaction.options.getUser('recipient');
-        const message = interaction.options.getString('message');
-        const regarding = interaction.options.getString('regarding');
+  try {
+    if (interaction.isCommand() && interaction.inGuild()) {
+      const subcommand = interaction.options.getSubcommand();
+      switch ([interaction.commandName, subcommand].join('.')) {
+        case 'daemon.kudos': {
+          const recipientOption = interaction.options.getUser('recipient');
+          const message = interaction.options.getString('message');
+          const regarding = interaction.options.getString('regarding');
 
-        const recipient = await interaction.guild.members.fetch(recipientOption.id);
+          const recipient = await interaction.guild.members.fetch(recipientOption.id);
 
-        const from = await interaction.guild.members.fetch(interaction.user.id);
+          const from = await interaction.guild.members.fetch(interaction.user.id);
 
-        const recipientVc = await createPunkProfileVc(recipient.id, {
-          name: recipient.displayName,
-          handle: `${recipient.user.username}#${recipient.user.discriminator}`,
-          discordId: recipient.id,
-          avatarUrl: recipient.user.displayAvatarURL({ size: 512 }),
-        });
+          const recipientVc = await createPunkProfileVc(recipient.id, {
+            name: recipient.displayName,
+            handle: `${recipient.user.username}#${recipient.user.discriminator}`,
+            discordId: recipient.id,
+            avatarUrl: recipient.user.displayAvatarURL({size: 512}),
+          });
 
-        const fromVc = await createPunkProfileVc(from.id, {
-          name: from.displayName,
-          handle: `${from.user.username}#${from.user.discriminator}`,
-          discordId: from.id,
-          avatarUrl: from.user.displayAvatarURL({ size: 512 }),
-        });
-        console.log(recipientVc, fromVc);
+          const fromVc = await createPunkProfileVc(from.id, {
+            name: from.displayName,
+            handle: `${from.user.username}#${from.user.discriminator}`,
+            discordId: from.id,
+            avatarUrl: from.user.displayAvatarURL({size: 512}),
+          });
+          console.log(recipientVc, fromVc);
 
-        const channel = interaction.channel as GuildChannel;
+          const channel = interaction.channel as GuildChannel;
 
-        const vc = await createKudosVc(recipient.id, interaction.user.id, interaction.guildId, {
-          message,
-          description: regarding,
-          channel: `#${channel.name}`,
-        });
+          const vc = await createKudosVc(recipient.id, interaction.user.id, interaction.guildId, {
+            message,
+            description: regarding,
+            channel: `#${channel.name}`,
+          });
 
-        console.log('Issued kudos VC:', vc);
-        const kudosMessage = await interaction.reply({
-          content: `Kudos! ${userMention(recipient.id)}\n\nReact with :+1: to second!`,
-          embeds: [
-            new MessageEmbed()
-              .setTitle(message)
-              .setDescription(regarding)
-              .setThumbnail(recipient.user.avatarURL())
-              .addField('From', userMention(interaction.user.id))
-              .addField('KudosID', vc.credentialSubject.credentialId)
-              .setTimestamp(),
-          ],
-          fetchReply: true,
-        });
-        if (kudosMessage instanceof Message) {
-          await kudosMessage.react('👍');
+          console.log('Issued kudos VC:', vc);
+          const kudosMessage = await interaction.reply({
+            content: `Kudos! ${userMention(recipient.id)}\n\nReact with :+1: to second!`,
+            embeds: [
+              new MessageEmbed()
+                .setTitle(message)
+                .setDescription(regarding)
+                .setThumbnail(recipient.user.avatarURL())
+                .addField('From', userMention(interaction.user.id))
+                .addField('KudosID', vc.credentialSubject.credentialId)
+                .setTimestamp(),
+            ],
+            fetchReply: true,
+          });
+          if (kudosMessage instanceof Message) {
+            await kudosMessage.react('👍');
+          }
+          break;
         }
-        break;
-      }
-      default: {
-        await interaction.reply({
-          content: 'Unknown interaction',
-          ephemeral: true,
-        });
+        default: {
+          await interaction.reply({
+            content: 'Unknown interaction',
+            ephemeral: true,
+          });
+        }
       }
     }
+  } catch(e) {
+    console.error('discordClient.interactionCreate', e);
   }
 });
 
 discordClient.on('messageReactionAdd', async (messageReaction) => {
-  if (messageReaction.partial) {
-    await messageReaction.fetch();
-  }
-  console.log('messageReactionAdd', messageReaction);
+  try {
+    if (messageReaction.partial) {
+      await messageReaction.fetch();
+    }
+    console.log('messageReactionAdd', messageReaction);
 
-  if (!messageReaction.message.embeds?.length) {
-    console.log('Missing embed');
-    return;
-  }
-
-  const [embed] = messageReaction.message.embeds;
-  const kudosIdField = embed.fields.find(f => f.name === 'KudosID');
-  if (!kudosIdField) {
-    console.log('Missing kudos ID field');
-    return;
-  }
-  const kudosId = kudosIdField.value;
-
-  await messageReaction.users.fetch();
-
-  const secondedUsers = [...messageReaction.users.cache.keys()].filter(id => id !== discordClient.user.id);
-  console.log([...messageReaction.users.cache.values()].map(u => u.displayAvatarURL({ size: 512 })));
-  console.log(secondedUsers);
-
-  const secondedKudos = await findSecondedKudos(kudosId);
-  const secondedKudosByDiscordId = _.keyBy(secondedKudos, sk => sk.credentialSubject.issuerId);
-
-  await Promise.all(secondedUsers.map(async (userId) => {
-    if (secondedKudosByDiscordId[userId]) {
-      console.log(`${userId} has already seconded kudos ${kudosId}`);
+    if (!messageReaction.message.embeds?.length) {
+      console.log('Missing embed');
       return;
     }
-    console.log(`Issuing seconded kudos from ${userId} for kudos ${kudosId}`);
-    await createSecondedKudosVc(userId, kudosId);
-  }))
+
+    const [embed] = messageReaction.message.embeds;
+    const kudosIdField = embed.fields.find(f => f.name === 'KudosID');
+    if (!kudosIdField) {
+      console.log('Missing kudos ID field');
+      return;
+    }
+    const kudosId = kudosIdField.value;
+
+    await messageReaction.users.fetch();
+
+    const secondedUsers = [...messageReaction.users.cache.keys()].filter(id => id !== discordClient.user.id);
+    console.log([...messageReaction.users.cache.values()].map(u => u.displayAvatarURL({ size: 512 })));
+    console.log(secondedUsers);
+
+    const secondedKudos = await findSecondedKudos(kudosId);
+    const secondedKudosByDiscordId = _.keyBy(secondedKudos, sk => sk.credentialSubject.issuerId);
+
+    await Promise.all(secondedUsers.map(async (userId) => {
+      if (secondedKudosByDiscordId[userId]) {
+        console.log(`${userId} has already seconded kudos ${kudosId}`);
+        return;
+      }
+      console.log(`Issuing seconded kudos from ${userId} for kudos ${kudosId}`);
+      await createSecondedKudosVc(userId, kudosId);
+    }));
+  } catch(e) {
+    console.error('discordClient.messageReactionAdd', e);
+  }
 });
 
 discordClient.on('guildJoin', async (guild) => {
-  // Issue guild DID
-  await createDaoDid(guild.id);
+  try {
+    // Issue guild DID and Profile VC
+    console.log(`Creating DID for ${guild.name}/${guild.id}`);
+    await createDaoProfileVc(guild.id, {
+      name: guild.name,
+      discordId: guild.id,
+      avatarUrl: guild.iconURL({ size: 512 }),
+    });
+  } catch(e) {
+    console.error('discordClient.guildJoin', e);
+  }
 });

--- a/packages/daemon/src/scripts/generate-data.ts
+++ b/packages/daemon/src/scripts/generate-data.ts
@@ -51,7 +51,7 @@ const createKudos = async (punk1:string, punk2:string, dao:string) => {
   const kudosVc = await createKudosVc(punk1, punk2, dao, {
     message: faker.hacker.phrase(),
     description: faker.hacker.phrase(),
-    channel: `#${faker.hacker.verb()}-${faker.hacker.noun()}`,
+    channel: `#${faker.hacker.verb()}-${faker.hacker.noun()}`.replace(' ','-'),
   });
   const credId = kudosVc.credentialSubject.credentialId;
   kudosIds.push(credId);
@@ -124,47 +124,20 @@ const main = async () => {
   });
 
   const dao1PunkDiscordId = await createPunkProfile({
-    name: 'coolDude',
-    handle: 'coolDude#1234',
+    name: '0xStan',
+    handle: '0xStan#1234',
     avatarUrl: 'https://cdn.discordapp.com/avatars/149991825703305217/8e4ec2c92c4fbe31201631ebc81c6289.png?size=512',
   });
   const dao1Punk2DiscordId = await createPunkProfile({
-    name: 'radMan',
-    handle: 'radMan#2345',
+    name: 'vBits',
+    handle: 'vBits#2345',
     avatarUrl: 'https://cdn.discordapp.com/avatars/510489920968589318/9f2fc3dad2d3a2f018b34f593f77cf9e.png?size=512',
   });
   const dao1Punk3DiscordId = await createPunkProfile({
-    name: 'intenseIndividual',
-    handle: 'intenseIndividual#3456',
+    name: 'Fifi_3pp',
+    handle: 'Fifi_3pp#3456',
     avatarUrl: 'https://cdn.discordapp.com/avatars/510490140758507546/f6af831ef51852741a2f430749dfb3bf.png?size=512',
   });
-  const vc1 = await createKudosVc(dao1PunkDiscordId, dao1Punk2DiscordId, banklessDiscordId, {
-    message: 'You\'re awesome!',
-    description: 'Because you did great on the thing! 👏👏👏',
-    channel: '#general',
-  });
-  const vc2 = await createKudosVc(dao1Punk2DiscordId, dao1PunkDiscordId, banklessDiscordId, {
-    message: 'You\'re great!',
-    description: 'Cuz you gave me kudos earlier! 🎉🎉',
-    channel: '#general',
-  });
-  await createKudosVc(dao1PunkDiscordId, dao1Punk3DiscordId, banklessDiscordId, {
-    message: 'You\'ve been killing it lately!',
-    description: 'Awesome work on XYZ',
-    channel: '#general',
-  });
-  await createKudosVc(dao1Punk2DiscordId, dao1Punk3DiscordId, banklessDiscordId, {
-    message: 'Thanks for helping with the hackathon',
-    description: 'Couldn\'t have done it without you!',
-    channel: '#general',
-  });
-  await createSecondedKudosVc(dao1Punk3DiscordId,
-    vc1.credentialSubject.credentialId,
-  );
-  await createSecondedKudosVc(dao1Punk3DiscordId,
-    vc2.credentialSubject.credentialId,
-  );
-
 
   // =========== Randomized Content =============
 
@@ -193,6 +166,34 @@ const main = async () => {
     const kudosId = _getRandomKudos();
     await createSecondedKudosVc(punk, kudosId);
   }
+
+  // Putting these hand-rolled VCs last so they appear first in the lists (chronologically latest)
+  const vc1 = await createKudosVc(dao1PunkDiscordId, dao1Punk2DiscordId, banklessDiscordId, {
+    message: 'Awesome demo of the latest front-end.  It\'s 🔥',
+    description: 'BB-Project Standup',
+    channel: '#dev-guild',
+  });
+  const vc2 = await createKudosVc(dao1Punk2DiscordId, dao1PunkDiscordId, banklessDiscordId, {
+    message: 'LFG! That\'s an awesome way to get the word out 🙏🏻',
+    description: 'Token drop planning',
+    channel: '#ideas',
+  });
+  await createKudosVc(dao1PunkDiscordId, dao1Punk3DiscordId, banklessDiscordId, {
+    message: 'Thanks for the huge lift on the test deploy yesterday. Do you sleep?',
+    description: 'Harberger Tax Solidity Contracts',
+    channel: '#♠️ | alpha-taskforce',
+  });
+  await createKudosVc(dao1Punk2DiscordId, dao1Punk3DiscordId, banklessDiscordId, {
+    message: 'Thanks for helping with the hackathon. Couldn\'t have done it without you! 🏅',
+    description: 'EthOnline 2021',
+    channel: '#general',
+  });
+  await createSecondedKudosVc(dao1Punk3DiscordId,
+    vc1.credentialSubject.credentialId,
+  );
+  await createSecondedKudosVc(dao1Punk3DiscordId,
+    vc2.credentialSubject.credentialId,
+  );
 
   // await _debugPrints();
 };

--- a/packages/daemon/src/scripts/generate-data.ts
+++ b/packages/daemon/src/scripts/generate-data.ts
@@ -35,10 +35,9 @@ const createDaoProfile = async (params: {name:string, blurb:string, avatarUrl:st
   daoDiscordIds.push(discordId);
   return discordId;
 }
-const createPunkProfile = async (params: {name:string, blurb?:string, avatarUrl:string}) => {
-  const { name, ...rest } = params;
+const createPunkProfile = async (params: {name:string, handle:string, blurb?:string, avatarUrl:string}) => {
+  const { name, handle, ...rest } = params;
   const discordId = _discId(name);
-  const handle = name;
   await createPunkProfileVc(discordId, {
     name,
     handle,
@@ -125,15 +124,18 @@ const main = async () => {
   });
 
   const dao1PunkDiscordId = await createPunkProfile({
-    name: 'coolDude#1234',
+    name: 'coolDude',
+    handle: 'coolDude#1234',
     avatarUrl: 'https://cdn.discordapp.com/avatars/149991825703305217/8e4ec2c92c4fbe31201631ebc81c6289.png?size=512',
   });
   const dao1Punk2DiscordId = await createPunkProfile({
-    name: 'radMan#2345',
+    name: 'radMan',
+    handle: 'radMan#2345',
     avatarUrl: 'https://cdn.discordapp.com/avatars/510489920968589318/9f2fc3dad2d3a2f018b34f593f77cf9e.png?size=512',
   });
   const dao1Punk3DiscordId = await createPunkProfile({
-    name: 'intenseIndividual#3456',
+    name: 'intenseIndividual',
+    handle: 'intenseIndividual#3456',
     avatarUrl: 'https://cdn.discordapp.com/avatars/510490140758507546/f6af831ef51852741a2f430749dfb3bf.png?size=512',
   });
   const vc1 = await createKudosVc(dao1PunkDiscordId, dao1Punk2DiscordId, banklessDiscordId, {
@@ -171,7 +173,8 @@ const main = async () => {
     const rndName = `${faker.hacker.adjective()}${faker.hacker.noun()}`.replace(' ','');
     const rndDiscordHandle = `${rndName}#${Math.floor(Math.random()*10000)}`;
     await createPunkProfile({
-      name: rndDiscordHandle,
+      name: rndName,
+      handle: rndDiscordHandle,
       avatarUrl: faker.image.avatar(),
     });
   }

--- a/pm2.config.cjs
+++ b/pm2.config.cjs
@@ -5,39 +5,28 @@ module.exports = {
             script: 'yarn d-space:start',
             args: '',
             watch: false,
-            // env: {
-            //     PUBLIC_URL: process.env.PUBLIC_URL,
-            //     NODE_ENV: 'development',
-            // },
-            // env_production: {
-            //     NODE_ENV: 'production',
-            // },
+            env: {
+                PUBLIC_URL: 'https://alpha.sobol.io/ethonline2021',
+                REACT_APP_ENV_PREFIX: '/ethonline2021',
+                REACT_APP_API_HOST: 'https://alpha.sobol.io/ethonline2021',
+                NODE_ENV: 'development',
+            },
         },
         {
             name: 'daorectory-api-build',
             script: 'yarn daemon:build-dev',
             args: '',
             watch: false,
-            // env: {
-            //     PUBLIC_URL: process.env.PUBLIC_URL,
-            //     NODE_ENV: 'development',
-            // },
-            // env_production: {
-            //     NODE_ENV: 'production',
-            // },
         },
         {
             name: 'daorectory-api',
             script: 'yarn daemon:run',
             args: '',
             watch: false,
-            // env: {
-            //     PUBLIC_URL: process.env.PUBLIC_URL,
-            //     NODE_ENV: 'development',
-            // },
-            // env_production: {
-            //     NODE_ENV: 'production',
-            // },
+            env: {
+                URI_PREFIX: '/ethonline2021',
+                NODE_ENV: 'development',
+            },
         },
     ],
 };

--- a/pm2.config.cjs
+++ b/pm2.config.cjs
@@ -2,7 +2,7 @@ module.exports = {
     apps: [
         {
             name: 'daorectory-ui',
-            script: 'yarn d-space:start',
+            script: 'yarn d-space:start-hosted',
             args: '',
             watch: false,
             env: {


### PR DESCRIPTION
The hosted setup:
- I hardcoded some alpha proxy changes to route `alpha.sobol.io/ethonline2021/api/*` to the alpha instance `:8081`, and all other `alpha.sobol.io/ethonline2021/*` content to `:3000` (and opened those ports temporarily on the instance)
- you can use `yarn connect` to hop onto the alpha host (convenience)
- I've checked out `daorectory` repo onto the alpha host `/home/ubuntu/daorectory` and am building and running the apps from here too
- I'm using `yarn start` command to launch everything via pm2 supplying env-specific URL prefixes for everything
- I've created `packages/daemon/.env` file directly on the alpha instance, and if we want to tweak which discord bot etc is used for demo, this is where we'd config it
- This is also were we'd run our data generation script to get our demo contents